### PR TITLE
Updating W01H01, W02H01 and W02H02 from JUnit4 to JUnit5.7.0

### DIFF
--- a/W01H01/src/test/UnitTests.java
+++ b/W01H01/src/test/UnitTests.java
@@ -1,7 +1,8 @@
 package test;
 
-import org.junit.Test;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import pgdp.hellopingu.Hello;
 
 import java.io.ByteArrayOutputStream;
@@ -14,7 +15,7 @@ public class UnitTests {
     public void checkMain() {
         System.setOut(new PrintStream(outputStreamCaptor));
         Hello.main(new String[]{});
-        Assert.assertEquals("Hello World" + System.lineSeparator() + "Süßer Pingu!", outputStreamCaptor.toString()
+        Assertions.assertEquals("Hello World" + System.lineSeparator() + "Süßer Pingu!", outputStreamCaptor.toString()
                 .trim());
         System.setOut(standardOut);
     }

--- a/W02H01/src/test/UnitTests.java
+++ b/W02H01/src/test/UnitTests.java
@@ -1,11 +1,14 @@
 package test;
 
-import org.junit.Test;
-import org.junit.Assert;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import pgdp.rectangles.Rectangle;
 import pgdp.rectangles.Vector2D;
+
 public class UnitTests {
+
     @Test
     public void TestAreaCalculation() {
         Vector2D v1 = new Vector2D(0, 2);
@@ -13,7 +16,7 @@ public class UnitTests {
 
         Rectangle r1 = new Rectangle(v1, v2);
 
-        Assert.assertEquals(6.0, r1.calculateArea(), 0.000001);
+        Assertions.assertEquals(6.0, r1.calculateArea(), 0.000001);
     }
 
     @Test
@@ -27,6 +30,6 @@ public class UnitTests {
 
         r1.shiftBy(shiftVector1);
 
-        Assert.assertEquals("Rectangle spanned by points [-2.0, 0.5] and [1.0, -1.5].", r1.toString());
+        Assertions.assertEquals("Rectangle spanned by points [-2.0, 0.5] and [1.0, -1.5].", r1.toString());
     }
 }

--- a/W02H02/src/test/UnitTests.java
+++ b/W02H02/src/test/UnitTests.java
@@ -1,7 +1,7 @@
 package test;
 
-import org.junit.Test;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import pgdp.saleuine.Kaufuin;
 import pgdp.saleuine.Market;
 import pgdp.saleuine.Order;
@@ -24,7 +24,7 @@ public class UnitTests {
         Order o1 = new Order(3, 4, 5);
 
         // Act & Assert
-        Assert.assertEquals("3 Krustentiere, 4 Sardellen und 5 Sardinen", o1.toString());
+        Assertions.assertEquals("3 Krustentiere, 4 Sardellen und 5 Sardinen", o1.toString());
     }
 
     @Test
@@ -36,9 +36,9 @@ public class UnitTests {
         o1.addOrder(new Order(1, 2, 3));
 
         // Assert
-        Assert.assertEquals(11, o1.getAmountCrustaceans());
-        Assert.assertEquals(22, o1.getAmountAnchovies());
-        Assert.assertEquals(33, o1.getAmountSardines());
+        Assertions.assertEquals(11, o1.getAmountCrustaceans());
+        Assertions.assertEquals(22, o1.getAmountAnchovies());
+        Assertions.assertEquals(33, o1.getAmountSardines());
     }
 
     @Test
@@ -47,9 +47,9 @@ public class UnitTests {
         Kaufuin k1 = new Kaufuin("T1", 20, 1000.0, 1, 2, 3);
 
         // Act & Assert
-        Assert.assertEquals(1, k1.getOrder().getAmountCrustaceans());
-        Assert.assertEquals(2, k1.getOrder().getAmountAnchovies());
-        Assert.assertEquals(3, k1.getOrder().getAmountSardines());
+        Assertions.assertEquals(1, k1.getOrder().getAmountCrustaceans());
+        Assertions.assertEquals(2, k1.getOrder().getAmountAnchovies());
+        Assertions.assertEquals(3, k1.getOrder().getAmountSardines());
     }
 
     @Test
@@ -61,9 +61,9 @@ public class UnitTests {
         k1.giveNewOrder(new Order(10, 20, 30));
 
         // Assert
-        Assert.assertEquals(10, k1.getOrder().getAmountCrustaceans());
-        Assert.assertEquals(20, k1.getOrder().getAmountAnchovies());
-        Assert.assertEquals(30, k1.getOrder().getAmountSardines());
+        Assertions.assertEquals(10, k1.getOrder().getAmountCrustaceans());
+        Assertions.assertEquals(20, k1.getOrder().getAmountAnchovies());
+        Assertions.assertEquals(30, k1.getOrder().getAmountSardines());
     }
 
     @Test
@@ -75,9 +75,9 @@ public class UnitTests {
         k1.addToOrder(new Order(10, 20, 30));
 
         // Assert
-        Assert.assertEquals(11, k1.getOrder().getAmountCrustaceans());
-        Assert.assertEquals(22, k1.getOrder().getAmountAnchovies());
-        Assert.assertEquals(33, k1.getOrder().getAmountSardines());
+        Assertions.assertEquals(11, k1.getOrder().getAmountCrustaceans());
+        Assertions.assertEquals(22, k1.getOrder().getAmountAnchovies());
+        Assertions.assertEquals(33, k1.getOrder().getAmountSardines());
     }
 
     @Test
@@ -86,7 +86,7 @@ public class UnitTests {
         Kaufuin k1 = new Kaufuin("T1", 20, 1000.0, 1, 2, 3);
 
         // Act & Assert
-        Assert.assertEquals("T1(20) hätte gerne 1 Krustentiere, 2 Sardellen und 3 Sardinen.", k1.giveInformation());
+        Assertions.assertEquals("T1(20) hätte gerne 1 Krustentiere, 2 Sardellen und 3 Sardinen.", k1.giveInformation());
     }
 
     @Test
@@ -101,7 +101,7 @@ public class UnitTests {
         k1.pay(99);
 
         // Assert
-        Assert.assertEquals("T1 zahlt 99.0 und hat noch 901.0PD übrig.", outputStreamCaptor.toString()
+        Assertions.assertEquals("T1 zahlt 99.0 und hat noch 901.0PD übrig.", outputStreamCaptor.toString()
                 .trim());
 
         // Cleanup
@@ -127,7 +127,7 @@ public class UnitTests {
 
         // Assert
         // note: removes the automatic-generated last line of console output
-        Assert.assertEquals("Neue Bestellung wird angenommen: T1(20) hätte gerne 1 Krustentiere, 2 Sardellen und 3 Sardinen." + System.lineSeparator() +
+        Assertions.assertEquals("Neue Bestellung wird angenommen: T1(20) hätte gerne 1 Krustentiere, 2 Sardellen und 3 Sardinen." + System.lineSeparator() +
                 "Die Bestellung kostet 154.0PD." + System.lineSeparator() +
                 "T1 zahlt 154.0 und hat noch 846.0PD übrig." + System.lineSeparator(), outputStreamCaptor.toString().substring(0, (outputStreamCaptor.toString()).length() - 2));
 
@@ -156,7 +156,7 @@ public class UnitTests {
 
         // Assert
         // note: this test can fail, even if the strings are equal. But as long as the strings are equal, this failed test can be ignored.
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 "Der Laden der Saleuine Claudia und Karl-Heinz hat am 1. Tag 154.0PD eingenommen." + System.lineSeparator() +
                         "Dafür wurden 1 Krustentiere, 2 Sardellen und 3 Sardinen verkauft." + System.lineSeparator() +
                         "Insgesamt hat der Laden 154.0PD eingenommen." + System.lineSeparator(),
@@ -188,7 +188,7 @@ public class UnitTests {
 
         // Assert
         // note: this test can fail, even if the strings are equal. But as long as the strings are equal, this failed test can be ignored.
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 "Der Laden der Saleuine Claudia und Karl-Heinz hat am 2. Tag 85.0PD eingenommen." + System.lineSeparator() +
                         "Dafür wurden 1 Krustentiere, 2 Sardellen und 3 Sardinen verkauft." + System.lineSeparator() +
                         "Insgesamt hat der Laden 255.0PD eingenommen." + System.lineSeparator(),


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22636066/140810381-afeca64b-3367-4a5d-bc6b-70d372648069.png)

Weil in W03H01 auch JUnit5.7.0 benutzt wurde und auch auf dem Screenshot in der Readme gezeigt wird, dass man JUnit5.7.0 auswählen soll, wäre es glaube ich sinnvoller für alle Tests die aktuellste Version von JUnit zu verwenden.