### PR TITLE
Added equal tests for null

### DIFF
--- a/W03H01/test/pgdp/searchengine/AuthorTest.java
+++ b/W03H01/test/pgdp/searchengine/AuthorTest.java
@@ -42,7 +42,9 @@ public class AuthorTest {
                 "max.mustermann@example.de", new Date(12, 10, 1990))));
         assertFalse(AUTHOR.equals(new Author("Max", "Musterfrau", "Pinguinstraße 1",
                 "max.mustermann@example.de", new Date(12, 10, 1990))));
-        
+
+        assertFalse(AUTHOR.equals(null));
+
         // siehe https://github.com/LadnerJonas/PGdP-Tests-WS21-22/issues/9
         /*assertFalse(AUTHOR.equals(new Author("Max", "Mustermann", "Pinguinstraße 1",
                 "max.mustermann@example.de", null)));*/

--- a/W03H01/test/pgdp/searchengine/DateTest.java
+++ b/W03H01/test/pgdp/searchengine/DateTest.java
@@ -18,6 +18,8 @@ public class DateTest {
 
         var date3 = new Date(1, 1, 1989);
         assertFalse(date1.equals(date3));
+
+        assertFalse(date1.equals(null));
     }
 
     @Test

--- a/W03H01/test/pgdp/searchengine/DocumentTest.java
+++ b/W03H01/test/pgdp/searchengine/DocumentTest.java
@@ -41,6 +41,9 @@ public class DocumentTest {
 
         var document2 = document();
         assertFalse(document2.equals(document1));
+
+        assertFalse(document1.equals(null));
+        assertFalse(document2.equals(null));
     }
 
     @Test

--- a/W03H01/test/pgdp/searchengine/ReviewTest.java
+++ b/W03H01/test/pgdp/searchengine/ReviewTest.java
@@ -40,6 +40,9 @@ public class ReviewTest {
         var review2 = review();
         assertTrue(review1.equals(review1));
         assertFalse(review1.equals(review2));
+
+        assertFalse(review1.equals(null));
+        assertFalse(review2.equals(null));
     }
 
     @Test


### PR DESCRIPTION
Since an object in Java is basically just a reference it can be null.

This is a typical problem since null objects can be passed as objects to methods. If a method is called on null an error will arise.