### PR TITLE
removed testNull()

### DIFF
--- a/W08H01/src/test/PathTests.java
+++ b/W08H01/src/test/PathTests.java
@@ -46,15 +46,6 @@ public class PathTests {
             positionOf(0, 0)
     );
   }
-
-  @Test
-  void testNull() {
-    Path p = new Path();
-    p.prepend(null);
-    assertEquals(1, p.toPositionSet(new Position(0,0)).size());
-    assertNull(p.toPositionSet(null));
-    assertNull(p.getStep(2));
-  }
   
   private Position positionOf(int i, int j) {
     return new Position(i, j);

--- a/W08H01/src/test/PathTests.java
+++ b/W08H01/src/test/PathTests.java
@@ -47,6 +47,18 @@ public class PathTests {
     );
   }
   
+  //Not needed because of https://zulip.in.tum.de/#narrow/stream/864-PGdP-W08H01--.20Rekursive.20Pfade/topic/Null.20Eingaben
+  
+  /*
+  @Test
+  void testNull() {
+    Path p = new Path();
+    p.prepend(null);
+    assertEquals(1, p.toPositionSet(new Position(0,0)).size());
+    assertNull(p.toPositionSet(null));
+    assertNull(p.getStep(2));
+  }*/
+  
   private Position positionOf(int i, int j) {
     return new Position(i, j);
   }


### PR DESCRIPTION
Homework Number **W08H01**:

You should delete the _testNull()_ because it can fail when handling null parameters in a diffrent way for example throwing an exception when trying to call _getStep(int index)_ with an index that is out of bounds. Throwing an exception should also be alowed like handling the null paramter and returning null. But the test just passes with one implementation and is all in all not needed because of instruction.

Also it can make someone think they need to change something even if it would work with their implementatin.

I clearly understand the idea of forcing clean code to pass the test but also other clean implementations would fail.

Citation of the homework instruction:
There is no instruction in the homework for handling invalid function parameter.

Additional Information:
https://zulip.in.tum.de/#narrow/stream/864-PGdP-W08H01--.20Rekursive.20Pfade/topic/Null.20Eingaben

[//]: <> (change [ ] to [x] in order to check the box)
- [x] Solution is not getting revealed
- [x] Files are formatted 
