### PR TITLE
Change of insertion order to better reflect the method's internal logic

### DIFF
--- a/W09H01/src/test/pgdp/hashset/TupleHashSetTest.java
+++ b/W09H01/src/test/pgdp/hashset/TupleHashSetTest.java
@@ -27,14 +27,14 @@ class TupleHashSetTest {
     String string0 = "Ladner";
     Integer int1 = 321;
     String string1 = "Jonas";
-    
+
     Tuple<Integer, String> tuple0 = new Tuple<>(int0, string0);
     Tuple<Integer, String> tuple0Duplicate = new Tuple<>(int0, string0);
     Tuple<Integer, String> tuple1 = new Tuple<>(int1, string1);
     Tuple<Integer, String> tuple2 = new Tuple<>(int1, string0);
-    
-    integerStringTupleHashSet0.insert(tuple0);
+
     integerStringTupleHashSet0.insert(tuple0Duplicate);
+    integerStringTupleHashSet0.insert(tuple0);
     integerStringTupleHashSet0.insert(tuple1);
     integerStringTupleHashSet0.insert(tuple2);
     
@@ -415,14 +415,5 @@ class TupleHashSetTest {
       tuplesInHashSet.add(integerIntegerTuple);
     }
     assertEquals(353, tuplesInHashSet.size());
-    Arrays.stream(tuples).forEach(integerIntegerTupleHashSet::insert);
-    
-    tuplesInHashSet = new ArrayList<>();
-    for (Tuple<Integer, Integer> integerIntegerTuple : integerIntegerTupleHashSet) {
-      tuplesInHashSet.add(integerIntegerTuple);
-    }
-    assertEquals(353, tuplesInHashSet.size());
-    
   }
-  
 }


### PR DESCRIPTION
Homework Number: W09H01

A short description of the changes proposed in the pull request:
Currently, `iterator()` makes it seem, as if `integerStringTupleHashSet0.insert(tuple0Duplicate)` discarded the tuple in favor of the already existing `tuple0`.
The catch is that TupleHashSet's insert method replaces the existing tuple with an equal tuple as opposed to TuplePool's insert method, which discards a given equal tuple.
That's why I changed the order of insertion to better reflect the method's internal logic.

You could also do the following instead, as TupleHashSet's `contains` method makes use of Tuple's `equals` method.
```java
- assertTrue(tuples.contains(tuple0));
+ assertTrue(tuples.contains(tuple0Duplicate));
```
:notes: _In the end, it doesn't even matter_ :notes: This "issue" may be kind of nitpicky, so do as you please :)

[//]: <> (change [ ] to [x] in order to check the box)
- [x] Solution is not getting revealed
- [x] Files are formatted 
